### PR TITLE
Support mapbox-gl up to v3.10.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     mapbox-gl:
-      specifier: 3.8.0
-      version: 3.8.0
+      specifier: 3.10.0
+      version: 3.10.0
     typescript:
       specifier: 5.8.3
       version: 5.8.3
@@ -34,7 +34,7 @@ importers:
         version: 3.4.3
       mapbox-gl:
         specifier: 'catalog:'
-        version: 3.8.0
+        version: 3.10.0
       rollup:
         specifier: ^4.43.0
         version: 4.43.0
@@ -52,7 +52,7 @@ importers:
         version: link:..
       mapbox-gl:
         specifier: 'catalog:'
-        version: 3.8.0
+        version: 3.10.0
       vue:
         specifier: ^3.3.11
         version: 3.5.16(typescript@5.8.3)
@@ -723,8 +723,8 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
-  mapbox-gl@3.8.0:
-    resolution: {integrity: sha512-7iQ6wxAf8UedbNYTzNsyr2J25ozIBA4vmKY0xUDXQlHEokulzPENwjjmLxHQGRylDpOmR0c8kPEbtHCaQE2eMw==}
+  mapbox-gl@3.10.0:
+    resolution: {integrity: sha512-YnQxjlthuv/tidcxGYU2C8nRDVXMlAHa3qFhuOJeX4AfRP72OMRBf9ApL+M+k5VWcAXi2fcNOUVgphknjLumjA==}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -1536,7 +1536,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  mapbox-gl@3.8.0:
+  mapbox-gl@3.10.0:
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.2
       '@mapbox/mapbox-gl-supported': 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,5 @@ packages:
   - example
 
 catalog:
-  mapbox-gl: 3.8.0
+  mapbox-gl: 3.10.0
   typescript: 5.8.3

--- a/src/private/mapbox-gl-version.ts
+++ b/src/private/mapbox-gl-version.ts
@@ -25,10 +25,23 @@ export interface MapboxGlVersion {
    * @remarks
    *
    * `true`: `FeatureIndex.lookupSymbolFeatures` takes 7 parameters.
+   * `isV3_9` preceeds.
    *
    * `false`: `FeatureIndex.lookupSymbolFeatures` takes 8 parameters.
    */
   readonly isV3_8: boolean;
+
+  /**
+   * Whether v3.9.0 or later.
+   *
+   * @remarks
+   *
+   * `true`: `FeatureIndex.lookupSymbolFeatures` takes `QrfQuery` instead of
+   * `filterSpec` and `filterLayerIDs`.
+   *
+   * `false`: see `isV3_8`.
+   */
+  readonly isV3_9: boolean;
 
   /**
    * Whether v2.11.1 or earlier.
@@ -50,6 +63,7 @@ export interface MapboxGlVersion {
 export function getMapboxGlVersion(map: Map): MapboxGlVersion {
   const isV3 = typeof map.style.getOwnLayerSourceCache !== 'undefined';
   const isV3_8 = typeof (map.style as Style)._serializedLayers === 'undefined';
+  const isV3_9 = typeof map.indoor !== 'undefined';
   const isLegacy = typeof map._isDragging === 'undefined';
-  return { isV3, isV3_8, isLegacy }
+  return { isV3, isV3_8, isV3_9, isLegacy }
 }

--- a/src/private/mapbox-types.ts
+++ b/src/private/mapbox-types.ts
@@ -28,9 +28,10 @@ export type Style = Map['style'] & {
   _getLayerSourceCache?: (layer: StyleLayer) => SourceCache | undefined;
 }
 
-export interface StyleLayer {
-  type: string;
-}
+export type StyleLayer = Map['style']['_layers'][string] & {
+  // v3.11.0 or later may take a parameter
+  is3D(terrainEnabled?: boolean): boolean;
+};
 
 export type Placement = Map['style']['placement'] & {
   transform: Transform;
@@ -102,7 +103,7 @@ export interface FeatureIndex {
     availableImages: string[],
     styleLayers: { [layerId: string]: StyleLayer },
   ): QueryResult
-  // v3.8.0 or later
+  // v3.8.0
   lookupSymbolFeatures(
     symbolFeatureIndexes: number[],
     bucketIndex: number,
@@ -117,7 +118,29 @@ export interface FeatureIndex {
     availableImages: string[],
     styleLayers: { [layerId: string]: StyleLayer },
   ): QueryResult
+  // v3.9.0 or later
+  lookupSymbolFeatures(
+    symbolFeatureIndexes: number[],
+    bucketIndex: number,
+    sourceLayerIndex: number,
+    query: QrfQuery,
+    availableImages: string[],
+  ): QueryResult;
 }
+
+// https://github.com/mapbox/mapbox-gl-js/blob/ed45b275610423e6d3c4716b071cb8e25198a528/src/source/query_features.ts#L19-L22
+export type QrfQuery = {
+  layers: QrfLayers;
+  sourceCache: SourceCache;
+};
+
+// https://github.com/mapbox/mapbox-gl-js/blob/ed45b275610423e6d3c4716b071cb8e25198a528/src/source/query_features.ts#L27
+export type QrfLayers = Record<string, QrfLayer>;
+
+export type QrfLayer = {
+  targets?: unknown[]; // actual element type is `QrfTarget` but won't matter
+  styleLayer: StyleLayer; // actual type is `TypedStyleLayer` but won't matter
+};
 
 export type QueryResult = {
   [layerId: string]: ({

--- a/src/private/qrf-query.ts
+++ b/src/private/qrf-query.ts
@@ -1,0 +1,38 @@
+import type { QrfQuery, SourceCache, Style, StyleLayer } from './mapbox-types';
+
+/**
+ * Makes a default `QrfQuery`s for a given `StyleLayer`.
+ *
+ * @remarks
+ *
+ * A tweaked version of the following code block:
+ * https://github.com/mapbox/mapbox-gl-js/blob/ed45b275610423e6d3c4716b071cb8e25198a528/src/style/style.ts#L3185-L3196
+ *
+ * @beta
+ */
+export function makeQrfQueryForStyleLayer(
+  style: Style,
+  styleLayer: StyleLayer,
+  sourceCache: SourceCache,
+) {
+  // NOTE: suppose `styleLayer` has features
+  // // Skip layers that don't have features.
+  // if (featurelessLayerTypes.has(styleLayer.type)) return;
+
+  // NOTE: sourceCache must have been resolved in our context
+  // const sourceCache = this.getOwnLayerSourceCache(styleLayer);
+  // assert(sourceCache, 'queryable layers must have a source');
+
+  // NOTE: has3DLayers should not matter but retained in case I miss something
+  const querySourceCache: QrfQuery & {has3DLayers?: boolean} = {sourceCache, layers: {}, has3DLayers: false};
+  if (styleLayer.is3D(!!style.terrain)) querySourceCache.has3DLayers = true;
+    querySourceCache.layers[styleLayer.fqid] = querySourceCache.layers[styleLayer.fqid] || {styleLayer, targets: []};
+  // NOTE: `targets` must not be empty, otherwise we will get nothing.
+  // in the original code, `filter` prop is specified, which is
+  // `undefined` in our context.
+  // I also applied a non-null assertion to `targets`; I do not know why the
+  // original code got no type error.
+  querySourceCache.layers[styleLayer.fqid].targets!.push({/*filter*/}); 
+
+  return querySourceCache;
+}

--- a/src/private/qrf-query.ts
+++ b/src/private/qrf-query.ts
@@ -1,7 +1,7 @@
 import type { QrfQuery, SourceCache, Style, StyleLayer } from './mapbox-types';
 
 /**
- * Makes a default `QrfQuery`s for a given `StyleLayer`.
+ * Makes a default `QrfQuery` for a given `StyleLayer`.
  *
  * @remarks
  *


### PR DESCRIPTION
### Proposed changes

- Supports `mapbox-gl` up to v3.10.0
  - `mapbox-gl` v3.9.0 had a major breaking change in terms of the internal implementation. `FeatureIndex.lookupSymbolFeatures` takes a `QrfQuery` instead  of `filterSpec` and `filterLayerIDs`.
  - The difference between v3.9.0 and v3.10.0 should not matter to this library.
  - `mapbox-gl` v3.8.0 and earlier still work.

### Related issues

- closes #8