### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,9 @@
-MIT License
+mapbox-collision-boxes license
 
-Copyright (c) 2022 codemonger
+Copyright (c) 2022 - 2025 codemonger
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Use of this software and files in this repository (the "Software") must comply
+with the Mapbox TOS and be with the relevant Mapbox product(s).
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/README.md
+++ b/README.md
@@ -76,22 +76,28 @@ If you want to project collision boxes to the actual screen, you have to subtrac
 
 [^1]: This constant is defined as `viewportPadding` at https://github.com/mapbox/mapbox-gl-js/blob/e29e113ff5e1f4c073f84b8cbe546006d2fb604f/src/symbol/collision_index.js#L50 which is not exported from `mapbox-gl`.
 
+## License
+
+Since this library borrows the code from `mapbox-gl`, the [Mapbox Web SDK license](https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license) should be applied.
+In a nutshell, you can use this library as long as you use it with the relevant Mapbox product(s) and comply with the Mapbox TOS.
+Anyway, I am not a lawyer, please use and modify this library **AT YOUR OWN RISK**.
+
 ## Development
 
 ### Resoving dependencies
 
 ```sh
-npm ci
+pnpm install --frozen-lockfile
 ```
 
 ### Type-checking
 
 ```sh
-npm run type-check
+pnpm type-check
 ```
 
 ### Building the library
 
 ```sh
-npm run build
+pnpm build
 ```

--- a/README_ja.md
+++ b/README_ja.md
@@ -76,22 +76,28 @@ xとyの両軸について実際の画面位置 + `100`[^1]になっています
 
 [^1]: この定数は`viewportPadding`として https://github.com/mapbox/mapbox-gl-js/blob/e29e113ff5e1f4c073f84b8cbe546006d2fb604f/src/symbol/collision_index.js#L50 に定義されていますが、`mapbox-gl`はエクスポートしていません。
 
+## ライセンス
+
+このライブラリは`mapbox-gl`からコードを拝借しているので、[Mapbox Web SDKライセンス](https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license)が適用されるはずです。
+簡単に言うと、Mapbox TOSに従って適切なMapbox製品と組み合わせている限り使用することができます。
+とはいえ私は法律の専門家ではないので、**皆さん自身の責任で**このライブラリをご使用ください。
+
 ## 開発
 
 ### 依存関係の解決
 
 ```sh
-npm ci
+pnpm install --frozen-lockfile
 ```
 
 ### タイプチェック
 
 ```sh
-npm run type-check
+pnpm type-check
 ```
 
 ### ライブラリをビルドする
 
 ```sh
-npm run build
+pnpm build
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -33,13 +33,13 @@ Please replace `<Your Mapbox Access Token Here>` with your Mapbox access token.
 ### Resolving dependencies
 
 ```sh
-npm install
+pnpm install --frozen-lockfile
 ```
 
 ### Running the example on a dev server
 
 ```sh
-npm run dev
+pnpm dev
 ```
 
 A dev server will be hosted on http://localhost:5173.

--- a/example/README_ja.md
+++ b/example/README_ja.md
@@ -33,13 +33,13 @@ export const MAPBOX_ACCESS_TOKEN = '<Your Mapbox Access Token Here>';
 ### 依存関係を解決する
 
 ```sh
-npm install
+pnpm install --frozen-lockfile
 ```
 
 ### 開発サーバーでサンプルを動かす
 
 ```sh
-npm run dev
+pnpm dev
 ```
 
 開発サーバーは http://localhost:5173 でホストされます。

--- a/src/private/collision-index.ts
+++ b/src/private/collision-index.ts
@@ -1,3 +1,15 @@
+/**
+ * Mocks `CollisionIndex`.
+ *
+ * @remarks
+ *
+ * All the code in this file is a modified copy of the source code of
+ * `mapbox-gl`. Be aware of the Mapbox Web SDK license:
+ * https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license
+ *
+ * @beta
+ */
+
 import type { mat4 } from 'gl-matrix';
 
 import type { Box } from '../types';

--- a/src/private/mapbox-types.ts
+++ b/src/private/mapbox-types.ts
@@ -3,9 +3,10 @@
  *
  * @remarks
  *
- * Conforms to `mapbox-gl` v2.9.2.
- *
- * Includes only minimal definitions necessary to implement this library.
+ * All the material in this file are derived from the source code of
+ * `mapbox-gl`, including only minimal definitions necessary to implement this
+ * library. Be aware of the Mapbox Web SDK license:
+ * https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license
  *
  * @beta
  */

--- a/src/private/mapbox-types.ts
+++ b/src/private/mapbox-types.ts
@@ -3,7 +3,7 @@
  *
  * @remarks
  *
- * All the material in this file are derived from the source code of
+ * All the material in this file is derived from the source code of
  * `mapbox-gl`, including only minimal definitions necessary to implement this
  * library. Be aware of the Mapbox Web SDK license:
  * https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license

--- a/src/private/projection-util.ts
+++ b/src/private/projection-util.ts
@@ -1,3 +1,15 @@
+/**
+ * Utilities for `Projection`.
+ *
+ * @remarks
+ *
+ * All the code in this file is a modified copy of the source code of
+ * `mapbox-gl`. Be aware of the Mapbox Web SDK license:
+ * https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license
+ *
+ * @beta
+ */
+
 import { mat4 } from 'gl-matrix';
 
 import type { OverscaledTileID, Projection, Transform } from './mapbox-types';

--- a/src/private/qrf-query.ts
+++ b/src/private/qrf-query.ts
@@ -1,3 +1,15 @@
+/**
+ * Utilities for `QrfQuery`.
+ *
+ * @remarks
+ *
+ * All the code in this file is a modified copy of the source code of
+ * `mapbox-gl`. Be aware of the Mapbox Web SDK license:
+ * https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license
+ *
+ * @beta
+ */
+
 import type { QrfQuery, SourceCache, Style, StyleLayer } from './mapbox-types';
 
 /**

--- a/src/private/symbol-size.ts
+++ b/src/private/symbol-size.ts
@@ -1,6 +1,12 @@
 /**
  * Mocks calculation of a symbol size.
  *
+ * @remarks
+ *
+ * All the code in this file is a modified copy of the source code of
+ * `mapbox-gl`. Be aware of the Mapbox Web SDK license:
+ * https://github.com/mapbox/mapbox-gl-js?tab=readme-ov-file#license
+ *
  * @beta
  */
 


### PR DESCRIPTION
### Proposed changes

- In the source files, explicitly states about borrowing `mapbox-gl` code to make sure that there is a licensing concern.
- Adds "License" section to README.
- Updates the `LICENSE` file.

### Related issues

- closes #11