### PR TITLE
Publish dev package to GitHub Packages

### DIFF
--- a/.github/workflows/publish-dev-package.yml
+++ b/.github/workflows/publish-dev-package.yml
@@ -1,0 +1,20 @@
+name: "Publish a developer package to GitHub npm registry"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-dev:
+    uses: ./.github/workflows/publish-package.yml
+
+    with:
+      npm-registry-url: "https://npm.pkg.github.com/"
+
+    secrets:
+      npm-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,70 @@
+name: "Publish a package to a specified npm registry"
+
+on:
+  workflow_call:
+    inputs:
+      npm-registry-url:
+        description: "URL of the npm registry to publish to; e.g., https://npm.pkg.github.com for GitHub Packages"
+        type: string
+        required: true
+
+    secrets:
+      npm-token:
+        description: "Token that is allowed to publish to the npm registry; e.g., secrets.GITHUB_TOKEN for GitHub Packages"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  node-version: 22
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get short commit hash
+        id: commit-hash
+        run: echo "short-commit-hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      # appends the short commit hash to the version number
+      # 1. reads the package.json file
+      # 2. replaces the version and saves it in the package.json
+      - name: Read package information
+        id: package-info
+        # uses the exact commit to prevent harmful updates
+        uses: jaywcjlove/github-action-package@f6a7afaf74f96a166243f05560d5af4bd4eaa570
+        with:
+          path: package.json
+      - name: Append short commit hash to the version
+        # uses the exact commit to prevent harmful updates
+        uses: jaywcjlove/github-action-package@f6a7afaf74f96a166243f05560d5af4bd4eaa570
+        with:
+          path: package.json
+          version: ${{ steps.package-info.outputs.version }}-${{ steps.commit-hash.outputs.short-commit-hash }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        # the version is specified in package.json
+
+      - name: Setup Node.js ${{ env.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.node-version }}
+          cache: pnpm
+          registry-url: ${{ inputs.npm-registry-url }}
+          scope: '@codemonger-io'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # the build script is executed by the prepare script
+      - name: Build and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm-token }}
+        run: pnpm publish --no-git-checks

--- a/README.md
+++ b/README.md
@@ -19,6 +19,40 @@ Please add this repository to your dependencies.
 npm install https://github.com/codemonger-io/mapbox-collision-boxes#v0.3.0
 ```
 
+#### Installing from GitHub Packages
+
+Whenever commits are pushed to the `main` branch, a _developer package_ is published to the npm registry managed by GitHub Packages.
+A _developer package_ bears the next release version but followed by a dash (`-`) plus the short commit hash; e.g., `0.3.0-abc1234` where `abc1234` is the short commit hash of the commit used to build the package (_snapshot_).
+You can find _developer packages_ [here](https://github.com/codemonger-io/mapbox-collision-boxes/pkgs/npm/mapbox-collision-boxes).
+
+##### Configuring a GitHub personal access token
+
+To install a _developer package_, you need to configure a **classic** GitHub personal access token (PAT) with at least the `read:packages` scope.
+Below briefly explains how to configure a PAT.
+Please refer to the [GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) for more details.
+
+Once you have a PAT, please create a `.npmrc` file in your home directory with the following contents:
+
+```
+//npm.pkg.github.com/:_authToken=$YOUR_GITHUB_PAT
+```
+
+Please replace `$YOUR_GITHUB_PAT` with your PAT.
+
+In the root directory of your project, create another `.npmrc` file with the following contents:
+
+```
+@codemonger-io:registry=https://npm.pkg.github.com
+```
+
+Then you can install a _developer package_ with the following command:
+
+```sh
+npm install @codemonger-io/mapbox-collision-boxes@0.3.0-abc1234
+```
+
+Please replace `abc1234` with the short commit hash of the _snapshot_ you want to install.
+
 ### Usage
 
 The following snippet is an example to collect features hidden by a clicked symbol on the screen.

--- a/README_ja.md
+++ b/README_ja.md
@@ -19,6 +19,40 @@ Mapboxマップ上の衝突ボックスを画面座標系で計算する、[Mapb
 npm install https://github.com/codemonger-io/mapbox-collision-boxes#v0.3.0
 ```
 
+#### GitHub Packagesからインストールする
+
+`main`ブランチにコミットがプッシュされるたびに、*開発者用パッケージ*がGitHub Packagesが管理するnpmレジストリにパブリッシュされます。
+*開発者用パッケージ*のバージョンは次のリリースバージョンにハイフン(`-`)と短いコミットハッシュつなげたものになります。例、`0.3.0-abc1234` (`abc1234`はパッケージをビルドするのに使ったコミット(*スナップショット*)の短いコミットハッシュ)。
+*開発者用パッケージ*は[こちら](https://github.com/codemonger-io/mapbox-collision-boxes/pkgs/npm/mapbox-collision-boxes)にあります。
+
+##### GitHubパーソナルアクセストークンの設定
+
+*開発者用パッケージ*をインストールするには、最低限`read:packages`スコープの**クラシック**GitHubパーソナルアクセストークン(PAT)を設定する必要があります。
+以下、簡単にPATの設定方法を説明します。
+より詳しくは[GitHubのドキュメント](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)をご参照ください。
+
+PATが手に入ったら以下の内容の`.npmrc`ファイルをホームディレクトリに作成してください。
+
+```
+//npm.pkg.github.com/:_authToken=$YOUR_GITHUB_PAT
+```
+
+`$YOUR_GITHUB_PAT`はご自身のPATに置き換えてください。
+
+プロジェクトのルートディレクトリには以下の内容の`.npmrc`ファイルを作成してください。
+
+```
+@codemonger-io:registry=https://npm.pkg.github.com
+```
+
+これで以下のコマンドで*開発者用パッケージ*をインストールできます。
+
+```sh
+npm install @codemonger-io/mapbox-collision-boxes@0.3.0-abc1234
+```
+
+`abc1234`はインストールしたい*スナップショット*の短いコミットハッシュに置き換えてください。
+
 ### 使い方
 
 以下のスニペットはクリックしたシンボルに画面上で隠されているFeatureを集めてくる例です。


### PR DESCRIPTION
### Proposed changes

Introduces a GitHub Actions workflow which publishes a developer package whenever commits are pushed to the `main` branch.

The `publish-dev-package` workflow starts when commits are pushed to the `main` branch and calls the `publish-package` workflow that does the job to publish a developer package.

A developer package has the version number followed by a dash (`-`) plus the short commit hash of the commit used to build the package.

### Related issues

- closes #16